### PR TITLE
Use a named connection vs. default to prevent collisions

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,110 @@
+{
+	// Project Specific
+	"excludeFiles": [
+		"node_modules/**",
+		"coverage/**"
+	],
+
+	// Added for JSX Support
+	"fileExtensions": [
+		".js"
+	],
+
+	// Normal jscsrc
+	"disallowKeywords": [
+		"with"
+	],
+	"disallowKeywordsOnNewLine": [
+		"else"
+	],
+	"disallowMixedSpacesAndTabs": "smart",
+	"disallowMultipleLineBreaks": true,
+	"disallowMultipleLineStrings": true,
+	"disallowMultipleSpaces": true,
+	"disallowMultipleVarDecl": "exceptUndefined",
+	"disallowNewlineBeforeBlockStatements": true,
+	"disallowOperatorBeforeLineBreak": [
+		"+",
+		"."
+	],
+	"disallowPaddingNewlinesInBlocks": true,
+	"disallowQuotedKeysInObjects": "allButReserved",
+	"disallowSpaceAfterObjectKeys": true,
+	"disallowSpaceAfterPrefixUnaryOperators": true,
+	"disallowSpaceBeforeBinaryOperators": [
+		",",
+		":"
+	],
+	"disallowSpaceBeforePostfixUnaryOperators": true,
+	"disallowSpacesInAnonymousFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowSpacesInCallExpression": true,
+	"disallowSpacesInFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowSpacesInNamedFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowTrailingComma": true,
+	"disallowTrailingWhitespace": true,
+	"maximumLineLength": null,
+	"requireBlocksOnNewline": true,
+	"requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+	"requireCapitalizedConstructors": true,
+	"requireCommaBeforeLineBreak": true,
+	"requireCurlyBraces": [
+		"if",
+		"else",
+		"for",
+		"while",
+		"do",
+		"try",
+		"catch"
+	],
+	"requireDotNotation": "except_snake_case",
+	"requireLineFeedAtFileEnd": true,
+	"requireOperatorBeforeLineBreak": true,
+	"requirePaddingNewLinesBeforeLineComments": null,
+	"requireParenthesesAroundIIFE": true,
+	"requireSemicolons": true,
+	"requireSpaceAfterBinaryOperators": true,
+	"requireSpaceAfterKeywords": [
+		"if",
+		"else",
+		"for",
+		"while",
+		"do",
+		"switch",
+		"return",
+		"try",
+		"catch"
+	],
+	"requireSpaceBeforeBinaryOperators": [
+		"=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "|=", "^=", "+=", "+", "-",
+		"*", "/", "%", "<<", ">>", ">>>", "&", "|", "^", "&&", "||", "===", "==", ">=", "<=", "<", ">", "!=", "!=="
+	],
+	"requireSpaceBeforeBlockStatements": true,
+	"requireSpaceBeforeObjectValues": true,
+	"requireSpaceBetweenArguments": true,
+	"requireSpacesInAnonymousFunctionExpression": {
+		"beforeOpeningCurlyBrace": true
+	},
+	"requireSpacesInConditionalExpression": true,
+	"requireSpacesInForStatement": true,
+	"requireSpacesInFunctionExpression": {
+		"beforeOpeningCurlyBrace": true
+	},
+	"requireSpacesInNamedFunctionExpression": {
+		"beforeOpeningCurlyBrace": true
+	},
+	"requireSpacesInsideArrayBrackets": "all",
+	"requireSpacesInsideObjectBrackets": "all",
+	"requireSpacesInsideParentheses": "all",
+	"validateIndentation": "\t",
+	"validateLineBreaks": "LF",
+	"validateQuoteMarks": {
+		"escape": true,
+		"mark": "\""
+	}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.1.x
+
+### 0.1.1
+ * Set default rabbit connection name to "metronic" to avoid collisions with other connections used by a service.
+ * Support for latest BigGulp (build/test)
+ * Formatting changes
+
+### 0.1.0
+Initial release

--- a/README.md
+++ b/README.md
@@ -8,24 +8,25 @@ A library that provides both publishing and subscribing adapters for metronic. T
 ```javascript
 // defaults shown
 {
-	fanout: 'metronic-all-ex',
-	topic: 'metronic-topic-ex',
+	fanout: "metronic-all-ex",
+	topic: "metronic-topic-ex",
 	connection: {
-		user: 'guest',
-		pass: 'guest',
-		server: '127.0.0.1',
+		name: "metronic",
+		user: "guest",
+		pass: "guest",
+		server: "127.0.0.1",
 		port: 5672,
 		timeout: 2000,
-		vhost: '%2f'
+		vhost: "%2f"
 	}
 }
 ```
 
 ## Use
 ```javascript
-var metronic = require( 'metronic' )();
+var metronic = require( "metronic" )();
 var config = { ... };
-var publisher = require( 'metronic-rabbit' )
+var publisher = require( "metronic-rabbit" )
 	.publisher( config );
 metronic.use( publisher );
 ```
@@ -37,15 +38,16 @@ metronic.use( publisher );
 ```javascript
 // defaults shown
 {
-	fanout: 'metronic-all-ex',
-	topic: 'metronic-topic-ex',
+	fanout: "metronic-all-ex",
+	topic: "metronic-topic-ex",
 	connection: {
-		user: 'guest',
-		pass: 'guest',
-		server: '127.0.0.1',
+	name: "metronic",
+		user: "guest",
+		pass: "guest",
+		server: "127.0.0.1",
 		port: 5672,
 		timeout: 2000,
-		vhost: '%2f'
+		vhost: "%2f"
 	},
 	queue: {
 		autoDelete: true,
@@ -59,17 +61,17 @@ metronic.use( publisher );
 
 ## Use
 ```javascript
-var metronic = require( 'metronic' )();
+var metronic = require( "metronic" )();
 // default values shown
-var statsd = require( 'metronic-statsd' )(
+var statsd = require( "metronic-statsd" )(
 	{
-		server: 'localhost'
+		server: "localhost"
 		port: 8125
 	}
 );
 metronic.use( statsd );
 
 var config = { ... };
-require( 'metronic-rabbit' )
+require( "metronic-rabbit" )
 	.subscriber( metronic, config );
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,26 +1,6 @@
-var gulp = require( 'gulp' );
-var bg = require( 'biggulp' )( gulp );
+var gulp = require( "gulp" );
+var bg = require( "biggulp/common-gulp" )( gulp );
 
-gulp.task( 'coverage', bg.withCoverage() );
-
-gulp.task( 'coverage-watch', function() {
-	bg.watch( [ 'coverage' ] );
+gulp.task( "ci-test", function() {
+	return bg.testBehaviorOnce();
 } );
-
-gulp.task( 'show-coverage', bg.showCoverage() );
-
-gulp.task( 'continuous-specs', function() {
-	return bg.test();
-} );
-
-gulp.task( 'specs-watch', function() {
-	bg.watch( [ 'continuous-specs' ] );
-} );
-
-gulp.task( 'test-and-exit', function() {
-	return bg.testOnce();
-} );
-
-gulp.task( 'default', [ 'coverage', 'coverage-watch' ], function() {} );
-gulp.task( 'specs', [ 'continuous-specs', 'specs-watch' ], function() {} );
-gulp.task( 'test', [ 'test-and-exit' ] );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronic-rabbit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rabbit adapters for metronic",
   "main": "src/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
       "url": "http://nerdventure.io"
     }
   ],
-  "license": "MIT License - http://opensource.org/licenses/MIT",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/LeanKit-Labs/metronic-rabbit/issues"
   },
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/LeanKit-Labs/metronic-rabbit",
   "devDependencies": {
-    "biggulp": "~0.0.2",
+    "biggulp": "~0.2.0",
     "chai": "^2.1.1",
     "chai-as-promised": "^4.3.0",
     "gulp": "^3.8.11",

--- a/spec/.jshintrc
+++ b/spec/.jshintrc
@@ -12,7 +12,7 @@
 	"camelcase" : true,   //force all variable names to use either camelCase style or UPPER_CASE with underscores
 	"curly"     : true,   //requires you to always put curly braces around blocks in loops and conditionals
 	"eqeqeq"    : true,   //prohibits the use of == and != in favor of === and !==
-	"forin"     : true,   //requires all `for in` loops to filter object's items with `hasOwnProperty()`
+	"forin"     : true,   //requires all `for in` loops to filter object"s items with `hasOwnProperty()`
 	"immed"     : true,   //prohibits the use of immediate function invocations without wrapping them in parentheses
 	"indent"    : 4,      //enforces specific tab width
 	"latedef"   : "nofunc",   //prohibits the use of a variable before it was defined
@@ -25,7 +25,7 @@
 	"regexp"    : false,  //prohibits the use of unsafe `.` in regular expressions
 	"undef"     : true,   //prohibits the use of explicitly undeclared variables
 	"unused"    : true,   //warns when you define and never use your variables
-	"strict"    : false,  //requires all functions to run in EcmaScript 5's strict mode
+	"strict"    : false,  //requires all functions to run in EcmaScript 5"s strict mode
 	"trailing"  : false,  //makes it an error to leave a trailing whitespace in your code
 	// "maxparams":      0,      //set the max number of formal parameters allowed per function,
 	// "maxdepth":       0,      //control how nested do you want your blocks to be
@@ -71,7 +71,7 @@
 
 	"browser"     : true,   //defines globals exposed by modern browsers
 	"couch"       : false,  //defines globals exposed by CouchDB
-	"devel"       : true,   //defines globals that are usually used for logging poor-man's debugging: `console`, `alert`, etc.
+	"devel"       : true,   //defines globals that are usually used for logging poor-man"s debugging: `console`, `alert`, etc.
 	"dojo"        : false,  //defines globals exposed by the Dojo Toolkit
 	"jquery"      : false,  //defines globals exposed by the jQuery JavaScript library
 	"mootools"    : false,  //defines globals exposed by the MooTools JavaScript framework
@@ -112,5 +112,5 @@
 	"nomen"    : false,  //disallows the use of dangling `_` in variables
 	"onevar"   : false,  //allows only one `var` statement per function
 	"passfail" : false,  //makes JSHint stop on the first error or warning
-	"white"    : false   //make JSHint check your source code against Douglas Crockford's JavaScript coding style
+	"white"    : false   //make JSHint check your source code against Douglas Crockford"s JavaScript coding style
 }

--- a/spec/behavior/publisher.spec.js
+++ b/spec/behavior/publisher.spec.js
@@ -1,170 +1,172 @@
-require( '../setup' );
+require( "../setup" );
 
-describe( 'Publisher', function() {
-	describe( 'without configuration', function() {
+describe( "Publisher", function() {
+	describe( "without configuration", function() {
 		var adapter, rabbit, stamp;
 		before( function() {
 			var setup = getSetup();
 			adapter = setup.publisher();
 			rabbit = setup.rabbit;
-			adapter.setConverter( require( 'metronic/convert' ) );
+			adapter.setConverter( require( "metronic/convert" ) );
 			stamp = Date.now();
 			adapter.onMetric( {
-				type: 'time',
-				key: 'test.duration',
+				type: "time",
+				key: "test.duration",
 				value: 1,
-				units: 's',
+				units: "s",
 				timestamp: stamp
 			} );
 			adapter.onMetric( {
-				type: 'meter',
-				key: 'test.meter',
+				type: "meter",
+				key: "test.meter",
 				value: 1,
-				units: '',
+				units: "",
 				timestamp: stamp
 			} );
 		} );
 
-		it( 'should pass default configuration on to rabbit', function() {
+		it( "should pass default configuration on to rabbit", function() {
 			rabbit.config.should.eql( {
 				connection: {
-					user: 'guest',
-					pass: 'guest',
-					server: '127.0.0.1',
+					name: "metronic",
+					user: "guest",
+					pass: "guest",
+					server: "127.0.0.1",
 					port: 5672,
 					timeout: 2000,
-					vhost: '%2f'
+					vhost: "%2f"
 				},
 				exchanges: [
-					{ name: 'metronic-all-ex', type: 'fanout' },
-					{ name: 'metronic-topic-ex', type: 'topic' }
+					{ name: "metronic-all-ex", type: "fanout" },
+					{ name: "metronic-topic-ex", type: "topic" }
 				],
 				bindings: [
-					{ exchange: 'metronic-all-ex', target: 'metronic-topic-ex', keys: [] },
+					{ exchange: "metronic-all-ex", target: "metronic-topic-ex", keys: [] }
 				]
 			} );
 		} );
 
-		it( 'should capture correct measures', function() {
+		it( "should capture correct measures", function() {
 			rabbit.published.should.eql( [
 				{
-					exchange: 'metronic-all-ex',
+					exchange: "metronic-all-ex",
 					message: {
 						correlationId: undefined,
-						routingKey: 'test.duration',
-						type: 'metronic.time',
+						routingKey: "test.duration",
+						type: "metronic.time",
 						body: {
-							key: 'test.duration',
+							key: "test.duration",
 							timestamp: stamp,
-							type: 'time',
-							units: 'ms',
+							type: "time",
+							units: "ms",
 							value: 1000
 						}
 					}
 				},
 				{
-					exchange: 'metronic-all-ex',
+					exchange: "metronic-all-ex",
 					message: {
 						correlationId: undefined,
-						routingKey: 'test.meter',
-						type: 'metronic.meter',
+						routingKey: "test.meter",
+						type: "metronic.meter",
 						body: {
-							key: 'test.meter',
+							key: "test.meter",
 							timestamp: stamp,
-							type: 'meter',
-							units: '',
+							type: "meter",
+							units: "",
 							value: 1
 						}
 					}
-				},
+				}
 			] );
 		} );
 	} );
 
-	describe( 'with configuration', function() {
+	describe( "with configuration", function() {
 		var adapter, rabbit, stamp;
 		var config = {
-			fanout: 'all.metrics',
-			topic: 'topic.metrics',
+			fanout: "all.metrics",
+			topic: "topic.metrics",
 			connection: {
-				server: 'my.rabbit.server',
-				vhost: '%2fmetrics'
+				server: "my.rabbit.server",
+				vhost: "%2fmetrics"
 			}
 		};
 		before( function() {
 			var setup = getSetup();
 			adapter = setup.publisher( config );
 			rabbit = setup.rabbit;
-			adapter.setConverter( require( 'metronic/convert' ) );
+			adapter.setConverter( require( "metronic/convert" ) );
 			stamp = Date.now();
 			adapter.onMetric( {
-				type: 'time',
-				key: 'test.duration',
+				type: "time",
+				key: "test.duration",
 				value: 1,
-				units: 's',
+				units: "s",
 				timestamp: stamp
 			} );
 			adapter.onMetric( {
-				type: 'meter',
-				key: 'test.meter',
+				type: "meter",
+				key: "test.meter",
 				value: 1,
-				units: '',
+				units: "",
 				timestamp: stamp
 			} );
 		} );
 
-		it( 'should pass modified configuration on to rabbit', function() {
+		it( "should pass modified configuration on to rabbit", function() {
 			rabbit.config.should.eql( {
 				connection: {
-					user: 'guest',
-					pass: 'guest',
-					server: 'my.rabbit.server',
+					name: "metronic",
+					user: "guest",
+					pass: "guest",
+					server: "my.rabbit.server",
 					port: 5672,
 					timeout: 2000,
-					vhost: '%2fmetrics'
+					vhost: "%2fmetrics"
 				},
 				exchanges: [
-					{ name: 'all.metrics', type: 'fanout' },
-					{ name: 'topic.metrics', type: 'topic' }
+					{ name: "all.metrics", type: "fanout" },
+					{ name: "topic.metrics", type: "topic" }
 				],
 				bindings: [
-					{ exchange: 'all.metrics', target: 'topic.metrics', keys: [] },
+					{ exchange: "all.metrics", target: "topic.metrics", keys: [] }
 				]
 			} );
 		} );
 
-		it( 'should capture correct measures', function() {
+		it( "should capture correct measures", function() {
 			rabbit.published.should.eql( [
 				{
-					exchange: 'all.metrics',
+					exchange: "all.metrics",
 					message: {
 						correlationId: undefined,
-						routingKey: 'test.duration',
-						type: 'metronic.time',
+						routingKey: "test.duration",
+						type: "metronic.time",
 						body: {
-							key: 'test.duration',
+							key: "test.duration",
 							timestamp: stamp,
-							type: 'time',
-							units: 'ms',
+							type: "time",
+							units: "ms",
 							value: 1000
 						}
 					}
 				},
 				{
-					exchange: 'all.metrics',
+					exchange: "all.metrics",
 					message: {
 						correlationId: undefined,
-						routingKey: 'test.meter',
-						type: 'metronic.meter',
+						routingKey: "test.meter",
+						type: "metronic.meter",
 						body: {
-							key: 'test.meter',
+							key: "test.meter",
 							timestamp: stamp,
-							type: 'meter',
-							units: '',
+							type: "meter",
+							units: "",
 							value: 1
 						}
 					}
-				},
+				}
 			] );
 		} );
 	} );
@@ -181,7 +183,7 @@ function getSetup() {
 			this.published.push( { exchange: exchange, message: message } );
 		}
 	};
-	var adapters = proxyquire( '../src/index', {
+	var adapters = proxyquire( "../src/index", {
 		wascally: rabbitMock
 	} );
 	return {

--- a/spec/behavior/subscriber.spec.js
+++ b/spec/behavior/subscriber.spec.js
@@ -1,81 +1,82 @@
-require( '../setup' );
+require( "../setup" );
 
-describe( 'Subscriber', function() {
-	describe( 'with missing queue name', function() {
+describe( "Subscriber", function() {
+	describe( "with missing queue name", function() {
 		var setup, metronic;
 		before( function() {
 			setup = getSetup();
 			metronic = getMetronic();
 		} );
 
-		it( 'should throw queue missing error', function() {
+		it( "should throw queue missing error", function() {
 			expect( function() {
 				setup.subscriber( metronic, {} );
 			} ).to.throw(
-				'Metronic Subscriber requires a queue to be set in the configuration.'
+				"Metronic Subscriber requires a queue to be set in the configuration."
 			);
 		} );
 	} );
 
-	describe( 'without configuration', function() {
+	describe( "without configuration", function() {
 		var adapter, rabbit, metronic, stamp;
 		before( function() {
 			var setup = getSetup();
 			metronic = getMetronic();
 			adapter = setup.subscriber( metronic, {
-				queue: { name: 'metronic-queue' }
+				queue: { name: "metronic-queue" }
 			} );
 			rabbit = setup.rabbit;
 			stamp = Date.now();
 			rabbit.emit(
-				'',
+				"",
 				{
 					correlationId: undefined,
-					routingKey: 'test.duration',
-					type: 'metronic.time',
+					routingKey: "test.duration",
+					type: "metronic.time",
 					body: {
-						key: 'test.duration',
+						key: "test.duration",
 						timestamp: stamp,
-						type: 'time',
-						units: 'ms',
+						type: "time",
+						units: "ms",
 						value: 1000
 					}
 				}
 			);
 			rabbit.emit(
-				'',
+				"",
 				{
 					correlationId: undefined,
-					routingKey: 'test.meter',
-					type: 'metronic.meter',
+					routingKey: "test.meter",
+					type: "metronic.meter",
 					body: {
-						key: 'test.meter',
+						key: "test.meter",
 						timestamp: stamp,
-						type: 'meter',
-						units: '',
+						type: "meter",
+						units: "",
 						value: 1
 					}
 				}
 			);
 		} );
 
-		it( 'should pass default configuration on to rabbit', function() {
+		it( "should pass default configuration on to rabbit", function() {
 			rabbit.config.should.eql( {
 				connection: {
-					user: 'guest',
-					pass: 'guest',
-					server: '127.0.0.1',
+					name: "metronic",
+					user: "guest",
+					pass: "guest",
+					server: "127.0.0.1",
 					port: 5672,
 					timeout: 2000,
-					vhost: '%2f'
+					vhost: "%2f"
 				},
 				exchanges: [
-					{ name: 'metronic-all-ex', type: 'fanout' },
-					{ name: 'metronic-topic-ex', type: 'topic' }
+					{ name: "metronic-all-ex", type: "fanout" },
+					{ name: "metronic-topic-ex", type: "topic" }
 				],
 				queues: [
 					{
-						name: 'metronic-queue',
+						name: "metronic-queue",
 						autoDelete: true,
 						durable: false,
 						persistent: false,
@@ -85,27 +86,27 @@ describe( 'Subscriber', function() {
 					}
 				],
 				bindings: [
-					{ exchange: 'metronic-all-ex', target: 'metronic-topic-ex', keys: [] },
-					{ exchange: 'metronic-all-ex', target: 'metronic-queue', keys: [] },
+					{ exchange: "metronic-all-ex", target: "metronic-topic-ex", keys: [] },
+					{ exchange: "metronic-all-ex", target: "metronic-queue", keys: [] }
 				]
 			} );
 		} );
 
-		it( 'should capture correct measures', function() {
+		it( "should capture correct measures", function() {
 			metronic.metrics.should.eql( [
 				{
-					key: 'test.duration',
-					type: 'time',
-					units: 'ms',
+					key: "test.duration",
+					type: "time",
+					units: "ms",
 					value: 1000,
 					meta: {
 						timestamp: stamp
 					}
 				},
 				{
-					key: 'test.meter',
-					type: 'meter',
-					units: '',
+					key: "test.meter",
+					type: "meter",
+					units: "",
 					value: 1,
 					meta: {
 						timestamp: stamp
@@ -115,71 +116,72 @@ describe( 'Subscriber', function() {
 		} );
 	} );
 
-	describe( 'with configuration', function() {
+	describe( "with configuration", function() {
 		var adapter, rabbit, metronic, stamp;
 		before( function() {
 			var setup = getSetup();
 			metronic = getMetronic();
 			adapter = setup.subscriber( metronic, {
-				fanout: 'all.metrics',
-				topic: 'topic.metrics',
-				queue: { name: 'metronic-queue' },
+				fanout: "all.metrics",
+				topic: "topic.metrics",
+				queue: { name: "metronic-queue" },
 				connection: {
-					server: 'my.rabbit.server',
-					vhost: '%2fmetrics'
+					server: "my.rabbit.server",
+					vhost: "%2fmetrics"
 				}
 			} );
 			rabbit = setup.rabbit;
 			stamp = Date.now();
 			rabbit.emit(
-				'',
+				"",
 				{
 					correlationId: undefined,
-					routingKey: 'test.duration',
-					type: 'metronic.time',
+					routingKey: "test.duration",
+					type: "metronic.time",
 					body: {
-						key: 'test.duration',
+						key: "test.duration",
 						timestamp: stamp,
-						type: 'time',
-						units: 'ms',
+						type: "time",
+						units: "ms",
 						value: 1000
 					}
 				}
 			);
 			rabbit.emit(
-				'',
+				"",
 				{
 					correlationId: undefined,
-					routingKey: 'test.meter',
-					type: 'metronic.meter',
+					routingKey: "test.meter",
+					type: "metronic.meter",
 					body: {
-						key: 'test.meter',
+						key: "test.meter",
 						timestamp: stamp,
-						type: 'meter',
-						units: '',
+						type: "meter",
+						units: "",
 						value: 1
 					}
 				}
 			);
 		} );
 
-		it( 'should pass default configuration on to rabbit', function() {
+		it( "should pass default configuration on to rabbit", function() {
 			rabbit.config.should.eql( {
 				connection: {
-					user: 'guest',
-					pass: 'guest',
-					server: 'my.rabbit.server',
+					name: "metronic",
+					user: "guest",
+					pass: "guest",
+					server: "my.rabbit.server",
 					port: 5672,
 					timeout: 2000,
-					vhost: '%2fmetrics'
+					vhost: "%2fmetrics"
 				},
 				exchanges: [
-					{ name: 'all.metrics', type: 'fanout' },
-					{ name: 'topic.metrics', type: 'topic' }
+					{ name: "all.metrics", type: "fanout" },
+					{ name: "topic.metrics", type: "topic" }
 				],
 				queues: [
 					{
-						name: 'metronic-queue',
+						name: "metronic-queue",
 						autoDelete: true,
 						durable: false,
 						persistent: false,
@@ -189,27 +191,27 @@ describe( 'Subscriber', function() {
 					}
 				],
 				bindings: [
-					{ exchange: 'all.metrics', target: 'topic.metrics', keys: [] },
-					{ exchange: 'all.metrics', target: 'metronic-queue', keys: [] },
+					{ exchange: "all.metrics", target: "topic.metrics", keys: [] },
+					{ exchange: "all.metrics", target: "metronic-queue", keys: [] }
 				]
 			} );
 		} );
 
-		it( 'should capture correct measures', function() {
+		it( "should capture correct measures", function() {
 			metronic.metrics.should.eql( [
 				{
-					key: 'test.duration',
-					type: 'time',
-					units: 'ms',
+					key: "test.duration",
+					type: "time",
+					units: "ms",
 					value: 1000,
 					meta: {
 						timestamp: stamp
 					}
 				},
 				{
-					key: 'test.meter',
-					type: 'meter',
-					units: '',
+					key: "test.meter",
+					type: "meter",
+					units: "",
 					value: 1,
 					meta: {
 						timestamp: stamp
@@ -219,51 +221,52 @@ describe( 'Subscriber', function() {
 		} );
 	} );
 
-	describe( 'with specific topics', function() {
+	describe( "with specific topics", function() {
 		var adapter, rabbit, metronic;
 		before( function() {
 			var setup = getSetup();
 			metronic = getMetronic();
 			adapter = setup.subscriber( metronic, {
-				fanout: 'all.metrics',
-				topic: 'topic.metrics',
-				queue: { name: 'metronic-queue', topics: [ 'topic.one', 'topic.two' ] },
+				fanout: "all.metrics",
+				topic: "topic.metrics",
+				queue: { name: "metronic-queue", topics: [ "topic.one", "topic.two" ] },
 				connection: {
-					server: 'my.rabbit.server',
-					vhost: '%2fmetrics'
+					server: "my.rabbit.server",
+					vhost: "%2fmetrics"
 				}
 			} );
 			rabbit = setup.rabbit;
 		} );
 
-		it( 'should pass default configuration on to rabbit', function() {
+		it( "should pass default configuration on to rabbit", function() {
 			rabbit.config.should.eql( {
 				connection: {
-					user: 'guest',
-					pass: 'guest',
-					server: 'my.rabbit.server',
+					name: "metronic",
+					user: "guest",
+					pass: "guest",
+					server: "my.rabbit.server",
 					port: 5672,
 					timeout: 2000,
-					vhost: '%2fmetrics'
+					vhost: "%2fmetrics"
 				},
 				exchanges: [
-					{ name: 'all.metrics', type: 'fanout' },
-					{ name: 'topic.metrics', type: 'topic' }
+					{ name: "all.metrics", type: "fanout" },
+					{ name: "topic.metrics", type: "topic" }
 				],
 				queues: [
 					{
-						name: 'metronic-queue',
+						name: "metronic-queue",
 						autoDelete: true,
 						durable: false,
 						persistent: false,
 						noAck: true,
 						subscribe: true,
-						topics: [ 'topic.one', 'topic.two' ]
+						topics: [ "topic.one", "topic.two" ]
 					}
 				],
 				bindings: [
-					{ exchange: 'all.metrics', target: 'topic.metrics', keys: [] },
-					{ exchange: 'topic.metrics', target: 'metronic-queue', keys: [ 'topic.one', 'topic.two' ] },
+					{ exchange: "all.metrics", target: "topic.metrics", keys: [] },
+					{ exchange: "topic.metrics", target: "metronic-queue", keys: [ "topic.one", "topic.two" ] }
 				]
 			} );
 		} );
@@ -278,13 +281,13 @@ function getSetup() {
 			this.config = cfg;
 		},
 		emit: function( type, msg ) {
-			this.handles[ '#' ]( msg );
+			this.handles[ "#" ]( msg );
 		},
 		handle: function( type, h ) {
-			this.handles[ '#' ] = h;
+			this.handles[ "#" ] = h;
 		}
 	};
-	var adapters = proxyquire( '../src/index', {
+	var adapters = proxyquire( "../src/index", {
 		wascally: rabbitMock
 	} );
 	return {

--- a/spec/integration/integrated.spec.js
+++ b/spec/integration/integrated.spec.js
@@ -1,5 +1,5 @@
-var metronic = require( 'metronic' )();
-var rabbit = require( '../../src/index' );
+var metronic = require( "metronic" )();
+var rabbit = require( "../../src/index" );
 var publisher = rabbit.publisher();
 metronic.use( publisher );
 
@@ -19,23 +19,23 @@ var mock = {
 		} );
 	}
 };
-rabbit.subscriber( mock, { queue: { name: 'metrics.queue' } } );
+rabbit.subscriber( mock, { queue: { name: "metrics.queue" } } );
 
-describe( 'Integration', function() {
+describe( "Integration", function() {
 	var stamp;
 	before( function() {
 		mock.deferred = when.defer();
 		stamp = Date.now();
-		metronic.emitMetric( 'test', '', 'test.key', 10 );
+		metronic.emitMetric( "test", "", "test.key", 10 );
 		return mock.deferred.promise;
 	} );
 
-	it( 'should receive published metrics', function() {
+	it( "should receive published metrics", function() {
 		mock.metrics.should.eql( [
 			{
-				type: 'test',
-				units: '',
-				key: 'test.key',
+				type: "test",
+				units: "",
+				key: "test.key",
 				value: 10,
 				meta: {
 					timestamp: stamp

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,9 +1,9 @@
-var chai = require( 'chai' );
-chai.use( require( 'chai-as-promised' ) );
+var chai = require( "chai" );
+chai.use( require( "chai-as-promised" ) );
 global.should = chai.should();
 global.expect = chai.expect;
-global._ = require( 'lodash' );
-global.fs = require( 'fs' );
-global.sinon = require( 'sinon' );
-global.proxyquire = require( 'proxyquire' ).noPreserveCache();
-global.when = require( 'when' );
+global._ = require( "lodash" );
+global.fs = require( "fs" );
+global.sinon = require( "sinon" );
+global.proxyquire = require( "proxyquire" ).noPreserveCache();
+global.when = require( "when" );

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,32 @@
 var convert;
-var _ = require( 'lodash' );
-var rabbit = require( 'wascally' );
+var _ = require( "lodash" );
+var rabbit = require( "wascally" );
 
 var publisherDefaults = {
-	fanout: 'metronic-all-ex',
-	topic: 'metronic-topic-ex',
+	fanout: "metronic-all-ex",
+	topic: "metronic-topic-ex",
 	connection: {
-		user: 'guest',
-		pass: 'guest',
-		server: '127.0.0.1',
+		name: "metronic",
+		user: "guest",
+		pass: "guest",
+		server: "127.0.0.1",
 		port: 5672,
 		timeout: 2000,
-		vhost: '%2f'
+		vhost: "%2f"
 	}
 };
 
 var subscriberDefaults = {
-	fanout: 'metronic-all-ex',
-	topic: 'metronic-topic-ex',
+	fanout: "metronic-all-ex",
+	topic: "metronic-topic-ex",
 	connection: {
-		user: 'guest',
-		pass: 'guest',
-		server: '127.0.0.1',
+		name: "metronic",
+		user: "guest",
+		pass: "guest",
+		server: "127.0.0.1",
 		port: 5672,
 		timeout: 2000,
-		vhost: '%2f'
+		vhost: "%2f"
 	},
 	queue: {
 		autoDelete: true,
@@ -38,29 +40,30 @@ var subscriberDefaults = {
 
 function publisher( cfg ) {
 	var config = _.merge( {}, publisherDefaults, cfg );
+	var connectionName = config.connection.name;
 	rabbit.configure( {
 		connection: config.connection,
 		exchanges: [
-			{ name: config.fanout, type: 'fanout' },
-			{ name: config.topic, type: 'topic' }
+			{ name: config.fanout, type: "fanout" },
+			{ name: config.topic, type: "topic" }
 		],
 		bindings: [
-			{ exchange: config.fanout, target: config.topic, keys: [] },
+			{ exchange: config.fanout, target: config.topic, keys: [] }
 		]
 	} );
 	return {
 		onMetric: function( data ) {
-			if ( data.type === 'time' ) {
-				data.value = convert( data.value, data.units, 'ms' );
-				data.units = 'ms';
+			if ( data.type === "time" ) {
+				data.value = convert( data.value, data.units, "ms" );
+				data.units = "ms";
 			}
 			rabbit.publish( config.fanout,
 				{
 					body: data,
 					correlationId: data.correlationId,
 					routingKey: data.key,
-					type: 'metronic.' + data.type
-				} );
+					type: "metronic." + data.type
+				}, connectionName );
 		},
 		setConverter: function( converter ) {
 			convert = converter;
@@ -72,7 +75,7 @@ function subscriber( metronic, cfg ) {
 	var config = _.merge( {}, subscriberDefaults, cfg );
 	var queue = config.queue;
 	if ( !queue.name ) {
-		throw new Error( 'Metronic Subscriber requires a queue to be set in the configuration.' );
+		throw new Error( "Metronic Subscriber requires a queue to be set in the configuration." );
 	}
 	var binding = queue.topics.length ?
 		{ exchange: config.topic, target: queue.name, keys: queue.topics } :
@@ -80,8 +83,8 @@ function subscriber( metronic, cfg ) {
 	var setup = {
 		connection: config.connection,
 		exchanges: [
-			{ name: config.fanout, type: 'fanout' },
-			{ name: config.topic, type: 'topic' }
+			{ name: config.fanout, type: "fanout" },
+			{ name: config.topic, type: "topic" }
 		],
 		queues: [ queue ],
 		bindings: [
@@ -89,11 +92,11 @@ function subscriber( metronic, cfg ) {
 			binding
 		]
 	};
-	rabbit.handle( '#', function( env ) {
+	rabbit.handle( "#", function( env ) {
 		var msg = env.body;
 		var meta = { timestamp: msg.timestamp };
 		_.merge( meta, env.headers );
-		_.merge( meta, _.omit( msg, [ 'type', 'key', 'value', 'units', 'timestamp' ] ) );
+		_.merge( meta, _.omit( msg, [ "type", "key", "value", "units", "timestamp" ] ) );
 		metronic.emitMetric( msg.type, msg.units, msg.key, msg.value, meta );
 	} );
 	rabbit.configure( setup );


### PR DESCRIPTION
- Set default rabbit connection name to "metronic" to avoid collisions with other connections used by a service.
- Support for latest BigGulp (build/test)
- Formatting changes (mostly changing ' to ")
